### PR TITLE
Add WithContextAndTeardown and fix SetTeardown

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -30,6 +30,20 @@ func WithContext(ctx context.Context) goprocess.Process {
 	return p
 }
 
+// WithContextAndTeardown is a helper function to set teardown at initiation
+// of WithContext
+func WithContextAndTeardown(ctx context.Context, tf goprocess.TeardownFunc) goprocess.Process {
+	if ctx == nil {
+		panic("nil Context")
+	}
+	p := goprocess.WithTeardown(tf)
+	go func() {
+		<-ctx.Done()
+		p.Close()
+	}()
+	return p
+}
+
 // WaitForContext makes p WaitFor ctx. When Closing, p waits for
 // ctx.Done(), before being Closed(). It is simply:
 //

--- a/impl-mutex.go
+++ b/impl-mutex.go
@@ -119,8 +119,16 @@ func (p *process) SetTeardown(tf TeardownFunc) {
 	if tf == nil {
 		tf = nilTeardownFunc
 	}
+
 	p.Lock()
-	p.teardown = tf
+	if p.teardown == nil {
+		select {
+		case <-p.Closed():
+			p.teardown = tf
+			p.closeErr = tf()
+		default:
+		}
+	}
 	p.Unlock()
 }
 


### PR DESCRIPTION
I have removed the occurence of all SetTeardown in https://github.com/ipfs/go-ipfs/pull/1385. So this PR is basically a lib sugar.