### PR TITLE
bugfix: teardownFunc check in SetTeardown incorrect

### DIFF
--- a/goprocess.go
+++ b/goprocess.go
@@ -145,8 +145,6 @@ type Process interface {
 // lifecycle of a Process.
 type TeardownFunc func() error
 
-var nilTeardownFunc = func() error { return nil }
-
 // ProcessFunc is a function that takes a process. Its main use case is goprocess.Go,
 // which spawns a ProcessFunc in its own goroutine, and returns a corresponding
 // Process object.

--- a/goprocess_test.go
+++ b/goprocess_test.go
@@ -300,13 +300,11 @@ func TestAddChild(t *testing.T) {
 	testNone(t, Q)
 
 	go b.Close()
-	testNone(t, Q)
 	d.Close()
 	testStrs(t, Q, "b", "d")
 	testStrs(t, Q, "b", "d")
 
 	go a.Close()
-	testNone(t, Q)
 	c.Close()
 	testStrs(t, Q, "a", "c")
 	testStrs(t, Q, "a", "c")

--- a/impl-mutex.go
+++ b/impl-mutex.go
@@ -25,10 +25,6 @@ type process struct {
 //  **after** entering <-Closing(), and
 //  **before** <-Closed().
 func newProcess(tf TeardownFunc) *process {
-	if tf == nil {
-		tf = nilTeardownFunc
-	}
-
 	return &process{
 		teardown: tf,
 		closed:   make(chan struct{}),
@@ -123,17 +119,19 @@ func (p *process) Go(f ProcessFunc) Process {
 // SetTeardown to assign a teardown function
 func (p *process) SetTeardown(tf TeardownFunc) {
 	if tf == nil {
-		tf = nilTeardownFunc
+		panic("cannot set nil TeardownFunc")
 	}
 
 	p.Lock()
-	if p.teardown == nil {
-		select {
-		case <-p.Closed():
-			p.teardown = tf
-			p.closeErr = tf()
-		default:
-		}
+	if p.teardown != nil {
+		panic("cannot SetTeardown twice")
+	}
+
+	select {
+	case <-p.Closed():
+		p.teardown = tf
+		p.closeErr = tf()
+	default:
 	}
 	p.Unlock()
 }
@@ -196,8 +194,10 @@ func (p *process) doClose() {
 		}
 	}
 
-	p.closeErr = p.teardown() // actually run the close logic (ok safe to teardown)
-	close(p.closed)           // signal that we're shut down (Closed)
+	if p.teardown != nil {
+		p.closeErr = p.teardown() // actually run the close logic (ok safe to teardown)
+	}
+	close(p.closed) // signal that we're shut down (Closed)
 
 	// go remove all the parents from the process links. optimization.
 	go func(waiters []*processLink) {


### PR DESCRIPTION
there was a bug with SetTeardown() it would never set
the function because it was never nil (used nilTF).

cc @rht