### PR TITLE
add in helpers to derive a context from a goprocess

### DIFF
--- a/context/derive.go
+++ b/context/derive.go
@@ -1,0 +1,59 @@
+package goprocessctx
+
+import (
+	"errors"
+	"time"
+
+	goprocess "github.com/jbenet/goprocess"
+	"golang.org/x/net/context"
+)
+
+const (
+	closing = iota
+	closed
+)
+
+type procContext struct {
+	done  <-chan struct{}
+	which int
+}
+
+// OnClosingContext derives a context from a given goprocess that will
+// be 'Done' when the process is closing
+func OnClosingContext(p goprocess.Process) context.Context {
+	return &procContext{
+		done:  p.Closing(),
+		which: closing,
+	}
+}
+
+// OnClosedContext derives a context from a given goprocess that will
+// be 'Done' when the process is closed
+func OnClosedContext(p goprocess.Process) context.Context {
+	return &procContext{
+		done:  p.Closed(),
+		which: closed,
+	}
+}
+
+func (c *procContext) Done() <-chan struct{} {
+	return c.done
+}
+
+func (c *procContext) Deadline() (time.Time, bool) {
+	return time.Time{}, false
+}
+
+func (c *procContext) Err() error {
+	if c.which == closing {
+		return errors.New("process closing")
+	} else if c.which == closed {
+		return errors.New("process closed")
+	} else {
+		panic("unrecognized process context type")
+	}
+}
+
+func (c *procContext) Value(key interface{}) interface{} {
+	return nil
+}


### PR DESCRIPTION
provide some helper functions (and type) to derive a context from a Process. This allows ipfs to do away with this: https://github.com/ipfs/go-ipfs/blob/master/thirdparty/waitable/waitable.go