### PR TITLE
reduce goroutine count when using processes with contexts

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -82,10 +82,10 @@ func CloseAfterContext(p goprocess.Process, ctx context.Context) {
 //
 func WithProcessClosing(ctx context.Context, p goprocess.Process) context.Context {
 	ctx, cancel := context.WithCancel(ctx)
-	go func() {
-		<-p.Closing()
+	goprocess.WithTeardown(func() error {
 		cancel()
-	}()
+		return nil
+	})
 	return ctx
 }
 
@@ -103,9 +103,10 @@ func WithProcessClosing(ctx context.Context, p goprocess.Process) context.Contex
 //
 func WithProcessClosed(ctx context.Context, p goprocess.Process) context.Context {
 	ctx, cancel := context.WithCancel(ctx)
-	go func() {
+	p.AddChildNoWait(goprocess.WithTeardown(func() error {
 		<-p.Closed()
 		cancel()
-	}()
+		return nil
+	}))
 	return ctx
 }

--- a/context/derive.go
+++ b/context/derive.go
@@ -2,58 +2,18 @@ package goprocessctx
 
 import (
 	"context"
-	"errors"
-	"time"
 
 	goprocess "github.com/jbenet/goprocess"
 )
 
-const (
-	closing = iota
-	closed
-)
-
-type procContext struct {
-	done  <-chan struct{}
-	which int
-}
-
 // OnClosingContext derives a context from a given goprocess that will
 // be 'Done' when the process is closing
 func OnClosingContext(p goprocess.Process) context.Context {
-	return &procContext{
-		done:  p.Closing(),
-		which: closing,
-	}
+	return WithProcessClosing(context.Background(), p)
 }
 
 // OnClosedContext derives a context from a given goprocess that will
 // be 'Done' when the process is closed
 func OnClosedContext(p goprocess.Process) context.Context {
-	return &procContext{
-		done:  p.Closed(),
-		which: closed,
-	}
-}
-
-func (c *procContext) Done() <-chan struct{} {
-	return c.done
-}
-
-func (c *procContext) Deadline() (time.Time, bool) {
-	return time.Time{}, false
-}
-
-func (c *procContext) Err() error {
-	if c.which == closing {
-		return errors.New("process closing")
-	} else if c.which == closed {
-		return errors.New("process closed")
-	} else {
-		panic("unrecognized process context type")
-	}
-}
-
-func (c *procContext) Value(key interface{}) interface{} {
-	return nil
+	return WithProcessClosed(context.Background(), p)
 }


### PR DESCRIPTION
1. Don't use custom contexts. Go special-cases it's own contexts to avoid goroutines.
2. Prefer subprocesses/teardowns over goroutines.

fixes #19