### PR TITLE
bunch of small fixes and optimizations

### DIFF
--- a/background.go
+++ b/background.go
@@ -1,0 +1,33 @@
+package goprocess
+
+// Background returns the "bgProcess" Process: a statically allocated
+// process that can _never_ close. It also never enters Closing() state.
+// Calling Background().Close() will hang indefinitely.
+func Background() Process {
+	return background
+}
+
+var background = new(bgProcess)
+
+type bgProcess struct{}
+
+func (*bgProcess) WaitFor(q Process)         {}
+func (*bgProcess) AddChildNoWait(q Process)  {}
+func (*bgProcess) AddChild(q Process)        {}
+func (*bgProcess) Close() error              { select {} }
+func (*bgProcess) CloseAfterChildren() error { select {} }
+func (*bgProcess) Closing() <-chan struct{}  { return nil }
+func (*bgProcess) Closed() <-chan struct{}   { return nil }
+func (*bgProcess) Err() error                { select {} }
+
+func (*bgProcess) SetTeardown(tf TeardownFunc) {
+	panic("can't set teardown on bgProcess process")
+}
+func (*bgProcess) Go(f ProcessFunc) Process {
+	child := newProcess(nil)
+	go func() {
+		f(child)
+		child.Close()
+	}()
+	return child
+}

--- a/context/context.go
+++ b/context/context.go
@@ -63,8 +63,11 @@ func CloseAfterContext(p goprocess.Process, ctx context.Context) {
 	}
 
 	go func() {
-		<-ctx.Done()
-		p.Close()
+		select {
+		case <-ctx.Done():
+			p.Close()
+		case <-p.Closed():
+		}
 	}()
 }
 

--- a/context/context.go
+++ b/context/context.go
@@ -56,9 +56,8 @@ func CloseAfterContext(p goprocess.Process, ctx context.Context) {
 		panic("nil Context")
 	}
 
-	// context.Background(). if ctx.Done() is nil, it will never be done.
-	// we check for this to avoid wasting a goroutine forever.
-	if ctx.Done() == nil {
+	// Avoid a goroutine for both context.Background() and goprocess.Background().
+	if ctx.Done() == nil || p.Closed() == nil {
 		return
 	}
 

--- a/context/context.go
+++ b/context/context.go
@@ -107,7 +107,10 @@ func WithProcessClosing(ctx context.Context, p goprocess.Process) context.Contex
 func WithProcessClosed(ctx context.Context, p goprocess.Process) context.Context {
 	ctx, cancel := context.WithCancel(ctx)
 	p.AddChildNoWait(goprocess.WithTeardown(func() error {
-		<-p.Closed()
+		select {
+		case <-p.Closed():
+		case <-ctx.Done():
+		}
 		cancel()
 		return nil
 	}))

--- a/goprocess.go
+++ b/goprocess.go
@@ -252,7 +252,7 @@ func WithParent(parent Process) Process {
 // This is useful to bind Process trees to syscall.SIGTERM, SIGKILL, etc.
 func WithSignals(sig ...os.Signal) Process {
 	p := WithParent(Background())
-	c := make(chan os.Signal)
+	c := make(chan os.Signal, 1)
 	signal.Notify(c, sig...)
 	go func() {
 		<-c

--- a/goprocess.go
+++ b/goprocess.go
@@ -261,24 +261,3 @@ func WithSignals(sig ...os.Signal) Process {
 	}()
 	return p
 }
-
-// Background returns the "background" Process: a statically allocated
-// process that can _never_ close. It also never enters Closing() state.
-// Calling Background().Close() will hang indefinitely.
-func Background() Process {
-	return background
-}
-
-// background is the background process
-var background = &unclosable{Process: newProcess(nil)}
-
-// unclosable is a process that _cannot_ be closed. calling Close simply hangs.
-type unclosable struct {
-	Process
-}
-
-func (p *unclosable) Close() error {
-	var hang chan struct{}
-	<-hang // hang forever
-	return nil
-}

--- a/goprocess_test.go
+++ b/goprocess_test.go
@@ -624,9 +624,9 @@ func TestBackground(t *testing.T) {
 	go b.Close()
 
 	select {
+	case <-time.After(50 * time.Millisecond):
 	case <-b.Closing():
 		t.Error("b.Closing() closed :(")
-	default:
 	}
 }
 

--- a/goprocess_test.go
+++ b/goprocess_test.go
@@ -628,6 +628,33 @@ func TestBackground(t *testing.T) {
 	case <-b.Closing():
 		t.Error("b.Closing() closed :(")
 	}
+
+	done := make(chan struct{})
+	proc := b.Go(func(p Process) {
+		<-done
+	})
+	select {
+	case <-time.After(50 * time.Millisecond):
+	case <-proc.Closing():
+		t.Error("proc closed")
+	}
+	close(done)
+	testClosed(t, proc)
+
+	proc2 := WithTeardown(func() error {
+		return nil
+	})
+	proc2.WaitFor(b)
+
+	go proc.Close()
+
+	testClosing(t, proc)
+
+	select {
+	case <-time.After(50 * time.Millisecond):
+	case <-proc2.Closed():
+		t.Error("proc2 closed")
+	}
 }
 
 func TestWithSignals(t *testing.T) {

--- a/link.go
+++ b/link.go
@@ -97,8 +97,15 @@ func (pl *processLink) AddToChild() {
 	cp := pl.Child()
 
 	// is it a *process ? if not... panic.
-	c, ok := cp.(*process)
-	if !ok {
+	var c *process
+	switch cp := cp.(type) {
+	case *process:
+		c = cp
+	case *bgProcess:
+		// Background process never closes so we don't need to do
+		// anything.
+		return
+	default:
 		panic("goprocess does not yet support other process impls.")
 	}
 


### PR DESCRIPTION
* Avoid goroutines in several cases.
* Fix a small race in signal handling.
* Fix `proc.WaitFor(Background())`.
* Special-case the background process to avoid unnecessary work.